### PR TITLE
(feat) Support XDG specification

### DIFF
--- a/internal/gerrit/demo.go
+++ b/internal/gerrit/demo.go
@@ -19,7 +19,7 @@ import (
 )
 
 func main() {
-	gobotPass, err := ioutil.ReadFile(filepath.Join(os.Getenv("HOME"), "keys", "gobot-golang-org.cookie"))
+	gobotPass, err := ioutil.ReadFile(filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "gobot", "keys", "gobot-golang-org.cookie"))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Changes:

   - Substitutes a user's `$HOME/keys` folder for `~/.config/gobot/keys` to support `XDG_CONFIG_HOME`